### PR TITLE
Fix local dev API port to match launchSettings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ python -m http.server 3000 --directory public
 npx serve public
 ```
 
-The frontend automatically detects when it is running on a local dev server (any `localhost` port other than 80/443) and points API calls directly at `http://localhost:5000/api`. No configuration needed.
+The frontend automatically detects when it is running on a local dev server (any `localhost` port other than 80/443) and points API calls directly at `http://localhost:5074/api`. No configuration needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cd src/Api
 dotnet run
 ```
 
-The API starts on `http://localhost:5000` by default. In development mode it uses `appsettings.Development.json`, which stores the SQLite database as `bgci.db` in the `src/Api/` working directory.
+The API starts on `http://localhost:5074` by default. In development mode it uses `appsettings.Development.json`, which stores the SQLite database as `bgci.db` in the `src/Api/` working directory.
 
 ### Frontend
 

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,5 @@
 const isDev = window.location.hostname === 'localhost' && !['80', '443', ''].includes(window.location.port);
-const API = isDev ? 'http://localhost:5000/api' : '/api';
+const API = isDev ? 'http://localhost:5074/api' : '/api';
 
 // ── State ──────────────────────────────────────────────────
 let allGames = [];


### PR DESCRIPTION
## Summary

- Corrects the hardcoded API port in `app.js` from `5000` to `5074` to match the port defined in `src/Api/Properties/launchSettings.json`
- Updates the README to reflect the correct local dev URL