### PR TITLE
Add BGG Bearer token authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 # Environment / secrets
 .env
 *.env.local
+appsettings.Development.json

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -21,7 +21,7 @@ builder.Services.AddMediatR(cfg =>
 
 // Infrastructure
 builder.Services.AddGameCollectionInfrastructure(connectionString);
-builder.Services.AddBggIntegrationInfrastructure();
+builder.Services.AddBggIntegrationInfrastructure(builder.Configuration);
 
 // CORS — allow the nginx-served frontend
 builder.Services.AddCors(options =>

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "Database": {
     "Path": "bgci.db"
+  },
+  "Bgg": {
+    "BearerToken": ""
   }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "Database": {
     "Path": "/data/bgci.db"
+  },
+  "Bgg": {
+    "BearerToken": ""
   }
 }

--- a/src/BggIntegration.Infrastructure/BggIntegration.Infrastructure.csproj
+++ b/src/BggIntegration.Infrastructure/BggIntegration.Infrastructure.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
   </ItemGroup>

--- a/src/BggIntegration.Infrastructure/DependencyInjection.cs
+++ b/src/BggIntegration.Infrastructure/DependencyInjection.cs
@@ -22,7 +22,7 @@ public static class DependencyInjection
 
             if (!string.IsNullOrWhiteSpace(bearerToken))
                 client.DefaultRequestHeaders.Authorization =
-                    new AuthenticationHeaderValue("Bearer", bearerToken);
+                    new AuthenticationHeaderValue("Bearer", bearerToken.Trim());
         });
 
         services.AddScoped<IBggTranslator, BggTranslator>();

--- a/src/BggIntegration.Infrastructure/DependencyInjection.cs
+++ b/src/BggIntegration.Infrastructure/DependencyInjection.cs
@@ -1,18 +1,28 @@
+using System.Net.Http.Headers;
 using BggIntegration.Application.Translation;
 using BggIntegration.Domain.Interfaces;
 using BggIntegration.Infrastructure.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BggIntegration.Infrastructure;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddBggIntegrationInfrastructure(this IServiceCollection services)
+    public static IServiceCollection AddBggIntegrationInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
+        var bearerToken = configuration["Bgg:BearerToken"];
+
         services.AddHttpClient<IBggClient, BggHttpClient>(client =>
         {
             client.Timeout = TimeSpan.FromSeconds(30);
             client.DefaultRequestHeaders.Add("User-Agent", "BoardGameCollectionInsights/1.0");
+
+            if (!string.IsNullOrWhiteSpace(bearerToken))
+                client.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", bearerToken);
         });
 
         services.AddScoped<IBggTranslator, BggTranslator>();


### PR DESCRIPTION
## Summary

- Adds `Bgg:BearerToken` configuration key to `appsettings.json` (empty placeholder committed; real token set locally or via environment variable)
- Sets `Authorization: Bearer <token>` header on the BGG HTTP client when a token is configured
- Adds `appsettings.Development.json` to `.gitignore` to prevent tokens from being accidentally committed
- Docker deployments can inject the token via the `Bgg__BearerToken` environment variable