### PR TITLE
Add configurable API URL for local dev and Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 deploy/.env
 *.env.local
 appsettings.Development.json
+
+# Local API config
+public/config.js

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,4 @@
-const isDev = window.location.hostname === 'localhost' && !['80', '443', ''].includes(window.location.port);
-const API = isDev ? 'http://localhost:5074/api' : '/api';
+const API = window.API_OVERRIDE ?? '/api';
 
 // ── State ──────────────────────────────────────────────────
 let allGames = [];

--- a/public/config.js.example
+++ b/public/config.js.example
@@ -1,0 +1,1 @@
+window.API_OVERRIDE = 'http://localhost:5074/api';

--- a/public/index.html
+++ b/public/index.html
@@ -109,6 +109,7 @@
     </div>
   </div>
 
+  <script src="config.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces hardcoded localhost:5074 detection with a configurable `window.API_OVERRIDE`
- Default is `/api` (relative path) for Docker deployments
- Local devs can create `public/config.js` from the example to override

## Changes
- `public/app.js`: Use `window.API_OVERRIDE ?? '/api'` instead of hostname detection
- `public/index.html`: Load `config.js` before `app.js`
- `public/config.js.example`: Added example config for local development
- `.gitignore`: Ignore `public/config.js`

## Local Dev Setup
1. Copy `public/config.js.example` → `public/config.js`
2. Edit `config.js` with local API URL (default: `http://localhost:5074/api`)
3. Serve frontend statically (e.g., `npx serve public`)