### PR TITLE
Fix branch reference in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Docker Images
 on:
   push:
     branches:
-      - main
+      - master
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
## Summary
- Changed the trigger branch from `main` to `master` in the publish workflow since the repository uses `master` as its default branch.