### PR TITLE
Fix BGG API URL: remove leading slashes from relative URLs in BggHttpClient

### DIFF
--- a/src/BggIntegration.Infrastructure/Http/BggHttpClient.cs
+++ b/src/BggIntegration.Infrastructure/Http/BggHttpClient.cs
@@ -37,21 +37,21 @@ public class BggHttpClient : IBggClient
 
 	public async Task<IReadOnlyList<BggSearchResult>> SearchAsync(string query, CancellationToken cancellationToken = default)
 	{
-		var url = $"/search?query={Uri.EscapeDataString(query)}&type=boardgame";
+		var url = $"search?query={Uri.EscapeDataString(query)}&type=boardgame";
 		var xml = await FetchXmlAsync(url, cancellationToken);
 		return BggXmlParser.ParseSearchResults(xml);
 	}
 
 	public async Task<BggGameDetails?> GetGameDetailsAsync(int bggId, CancellationToken cancellationToken = default)
 	{
-		var url = $"/thing?id={bggId}&stats=1";
+		var url = $"thing?id={bggId}&stats=1";
 		var xml = await FetchXmlAsync(url, cancellationToken);
 		return BggXmlParser.ParseGameDetails(xml, bggId);
 	}
 
 	public async Task<IReadOnlyList<BggCollectionItem>> GetCollectionAsync(string username, CancellationToken cancellationToken = default)
 	{
-		var url = $"/collection?username={Uri.EscapeDataString(username)}&own=1&excludesubtype=boardgameexpansion";
+		var url = $"collection?username={Uri.EscapeDataString(username)}&own=1&excludesubtype=boardgameexpansion";
 		var xml = await FetchXmlAsync(url, cancellationToken);
 		return BggXmlParser.ParseCollection(xml);
 	}
@@ -59,7 +59,7 @@ public class BggHttpClient : IBggClient
 	private async Task<XDocument> FetchXmlAsync(string url, CancellationToken cancellationToken)
 	{
 		using var response = await _bggPollingPipeline.ExecuteAsync(
-			async ct => await _http.GetAsync(url, ct),
+			async ct => await _http.GetAsync($"{ _http.BaseAddress}/{url}", ct),
 			cancellationToken);
 
 		if (response.StatusCode == HttpStatusCode.Accepted)


### PR DESCRIPTION
## Summary

- Removes leading `/` from all relative URLs in `BggHttpClient.cs` (`search`, `thing`, `collection` endpoints)
- Also explicitly constructs the full URL in `FetchXmlAsync` to ensure correct resolution against `BaseAddress`

Closes #18