### PR TITLE
fix: use runtime APP_VERSION env var for version badge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
-          build-args: VERSION=${{ steps.meta-api.outputs.version }}
+          build-args: DISPLAY_VERSION=${{ steps.meta-api.outputs.version }}
 
       - name: Extract metadata for Web image
         id: meta-web

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /build
 
-ARG VERSION=dev
-
 COPY src/ ./
 RUN dotnet restore bgci.slnx
-RUN dotnet publish Api/Api.csproj -c Release -o /app/publish --no-restore /p:Version=$VERSION
+RUN dotnet publish Api/Api.csproj -c Release -o /app/publish --no-restore
 
 # ── Runtime stage ──────────────────────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
+
+ARG DISPLAY_VERSION=dev
+ENV APP_VERSION=$DISPLAY_VERSION
 
 COPY --from=build /app/publish .
 

--- a/public/app.js
+++ b/public/app.js
@@ -94,7 +94,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 	const config = await loadConfig();
 	if (config.version) {
 		const badge = document.getElementById('app-version');
-		if (badge) badge.textContent = config.version === 'dev' ? 'dev' : `v${config.version}`;
+		if (badge) badge.textContent = (config.version === 'dev' || config.version === 'latest') ? config.version : `v${config.version}`;
 	}
 	applyBggAvailability(config);
 	if (config.bggSyncEnabled) {

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -15,8 +15,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version Condition="'$(VERSION)' != ''">$(VERSION)</Version>
-    <Version Condition="'$(VERSION)' == ''">0.0.0-dev</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Api/Controllers/ConfigController.cs
+++ b/src/Api/Controllers/ConfigController.cs
@@ -3,7 +3,6 @@ using BggIntegration.Domain.Models;
 using BggIntegration.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using System.Reflection;
 
 namespace Api.Controllers;
 
@@ -34,12 +33,7 @@ public class ConfigController : ControllerBase
 		var bggConfigured = !string.IsNullOrWhiteSpace(_bggSettings.BearerToken) && !string.IsNullOrWhiteSpace(_bggWriterSettings.BaseUrl);
 		var bggReachable = _bggAvailability.IsAvailable;
 
-		var infoVersion = Assembly.GetEntryAssembly()
-			?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-			?.InformationalVersion;
-		// Strip build metadata (e.g. "+abcdef"); return "dev" for non-release builds
-		var rawVersion = infoVersion?.Split('+')[0];
-		var version = rawVersion is null || rawVersion.Contains('-') ? "dev" : rawVersion;
+		var version = Environment.GetEnvironmentVariable("APP_VERSION") is { Length: > 0 } v ? v : "dev";
 
 		return Ok(new
 		{

--- a/src/Api/Controllers/ConfigController.cs
+++ b/src/Api/Controllers/ConfigController.cs
@@ -33,7 +33,8 @@ public class ConfigController : ControllerBase
 		var bggConfigured = !string.IsNullOrWhiteSpace(_bggSettings.BearerToken) && !string.IsNullOrWhiteSpace(_bggWriterSettings.BaseUrl);
 		var bggReachable = _bggAvailability.IsAvailable;
 
-		var version = Environment.GetEnvironmentVariable("APP_VERSION") is { Length: > 0 } v ? v : "dev";
+		var raw = Environment.GetEnvironmentVariable("APP_VERSION")?.Trim();
+		var version = string.IsNullOrWhiteSpace(raw) ? "dev" : raw.TrimStart('v');
 
 		return Ok(new
 		{


### PR DESCRIPTION
## Summary

- Removes assembly `InformationalVersion` reflection from `ConfigController` — the API project is not a NuGet package so assembly version metadata is the wrong mechanism
- Passes `DISPLAY_VERSION` as a Docker build arg into the runtime stage, baked in as the `APP_VERSION` environment variable
- API reads `APP_VERSION` env var directly; falls back to `"dev"` when absent (local development)
- Frontend badge handles `"latest"` without a `v` prefix (same as `"dev"`)

## Version badge behaviour after this fix

| Context | `APP_VERSION` | Badge |
|---|---|---|
| Local dev (no Docker) | _(absent)_ | `dev` |
| Docker — `master` push | `latest` | `latest` |
| Docker — `v1.2.3` tag | `1.2.3` | `v1.2.3` |

Closes #26